### PR TITLE
R compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ bottleneck/build/
 ann/lib
 ann/bin
 ann/lib/dummy
+*.DS_Store

--- a/include/hera/bottleneck/bottleneck_detail.hpp
+++ b/include/hera/bottleneck/bottleneck_detail.hpp
@@ -468,12 +468,10 @@ namespace hera {
 
             BoundMatchOracle<Real> oracle(A, B, distEpsilon, useRangeSearch);
             // binary search
-            size_t iterNum { 0 };
             size_t idxMin { 0 }, idxMax { pairwiseDist.size() - 1 };
             size_t idxMid;
             while (idxMax > idxMin) {
                 idxMid = static_cast<size_t>(floor(idxMin + idxMax) / 2);
-                iterNum++;
                 // not A[imid] < dist <=>  A[imid] >= dist  <=> A[imid[ >= dist + eps
                 if (oracle.isMatchLess(pairwiseDist[idxMid] + distEpsilon / 2)) {
                     idxMax = idxMid;

--- a/include/hera/common/diagram_reader.h
+++ b/include/hera/common/diagram_reader.h
@@ -123,7 +123,9 @@ template<class RealType = double, class ContType_ = std::vector<std::pair<RealTy
 inline bool read_diagram_point_set(const char* fname, ContType_& result, int& decPrecision)
 {
     bool zero_pers_warning_printed = false;
+#ifndef FOR_R_TDA
     size_t lineNumber { 0 };
+#endif
     result.clear();
     std::ifstream f(fname);
     if (!f.good()) {
@@ -135,7 +137,9 @@ inline bool read_diagram_point_set(const char* fname, ContType_& result, int& de
     std::locale loc;
     std::string line;
     while(std::getline(f, line)) {
+#ifndef FOR_R_TDA
         lineNumber++;
+#endif
         // process comments: remove everything after hash
         auto hashPos = line.find_first_of("#", 0);
         if( std::string::npos != hashPos) {
@@ -189,7 +193,9 @@ inline bool read_diagram_point_set(const char* fname, ContType_& result, int& de
                 result.push_back(std::make_pair(x, y));
             } else {
                 if (!zero_pers_warning_printed) {
+#ifndef FOR_R_TDA
                     std::cerr << "Warning: point with 0 persistence ignored in " << fname << ":" << lineNumber << "\n";
+#endif
                     zero_pers_warning_printed = true;
                 }
             }
@@ -292,7 +298,9 @@ inline bool read_diagram_dipha(const std::string& fname, unsigned int dim, ContT
 
         if ((unsigned int)d == dim) {
             if (death == birth && !zero_pers_warning_printed) {
+#ifndef FOR_R_TDA
                 std::cerr << "Warning: point with 0 persistence ignored in " << fname << "." << std::endl;
+#endif
                 zero_pers_warning_printed = true;
             } else {
                 result.push_back(std::make_pair(birth, death));
@@ -377,8 +385,9 @@ template<class RealType = double >
 inline bool read_point_cloud(const char* fname, hera::ws::dnn::DynamicPointVector<RealType>& result, int& dimension, int& decPrecision)
 {
     using DynamicPointTraitsR = typename hera::ws::dnn::DynamicPointTraits<RealType>;
-
+#ifndef FOR_R_TDA
     size_t lineNumber { 0 };
+#endif
     result.clear();
     std::ifstream f(fname);
     if (!f.good()) {
@@ -392,7 +401,9 @@ inline bool read_point_cloud(const char* fname, hera::ws::dnn::DynamicPointVecto
     bool dim_computed = false;
     int point_idx = 0;
     while(std::getline(f, line)) {
+#ifndef FOR_R_TDA
         lineNumber++;
+#endif
         // process comments: remove everything after hash
         auto hashPos = line.find_first_of("#", 0);
         if( std::string::npos != hashPos) {

--- a/include/hera/wasserstein/auction_runner_gs.hpp
+++ b/include/hera/wasserstein/auction_runner_gs.hpp
@@ -40,7 +40,6 @@ derivative works thereof, in binary and source code form.
 #define PRINT_DETAILED_TIMING
 
 #ifdef FOR_R_TDA
-#include "Rcpp.h"
 #undef DEBUG_AUCTION
 #endif
 
@@ -167,12 +166,14 @@ void AuctionRunnerGS<R, AO, PC>::run_auction()
     } else {
         run_auction_phases();
 
+#ifdef DEBUG_AUCTION
         if (result.final_relative_error > params.delta and not params.tolerate_max_iter_exceeded) {
             std::cerr << "Maximum iteration number exceeded, exiting. Current result is: ";
             std::cerr << pow(result.cost, 1 / params.wasserstein_power) << std::endl;
             if (not params.tolerate_max_iter_exceeded)
                 throw std::runtime_error("Maximum iteration number exceeded");
         }
+#endif
     }
 
     result.compute_distance(params.wasserstein_power);

--- a/include/hera/wasserstein/auction_runner_jac.hpp
+++ b/include/hera/wasserstein/auction_runner_jac.hpp
@@ -39,7 +39,6 @@ derivative works thereof, in binary and source code form.
 
 
 #ifdef FOR_R_TDA
-#include "Rcpp.h"
 #undef DEBUG_AUCTION
 #endif
 
@@ -432,11 +431,7 @@ namespace ws {
     void AuctionRunnerJac<R, AO, PC>::run_bidding_step(const Range &active_bidders)
     {
         clear_bid_table();
-        size_t bids_submitted = 0;
         for (const auto bidder_idx : active_bidders) {
-
-            ++bids_submitted;
-
             submit_bid(bidder_idx, oracle.get_optimal_bid(bidder_idx));
         }
 


### PR DESCRIPTION
Specifically:

- Added several missing `FOR_R_TDA` symbols;
- Removed unused counter variables that generated compilation warnings;
- Removed use of `Rcpp.h` header as this forces R developers to necessarily use {hera} with {Rcpp} while some might not want to rely on {Rcpp}.